### PR TITLE
docs: add installation, usage examples and options to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,99 @@
 > [![Side Effect][side-effect-image]][bundle-phobia-url]
 > [![License][license-image]][license-url]
 
+## Install
+
+```bash
+pnpm add -D @nuintun/svgo-loader svgo
+```
+
+> You can also use `npm` or `yarn`.
+
+## Usage
+
+### Webpack
+
+```js
+// webpack.config.js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.svg$/i,
+        type: 'asset/resource',
+        use: [
+          {
+            loader: '@nuintun/svgo-loader',
+            options: {
+              configFile: false,
+              multipass: true,
+              plugins: ['preset-default']
+            }
+          }
+        ]
+      }
+    ]
+  }
+};
+```
+
+### Rspack
+
+```js
+// rspack.config.js
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.svg$/i,
+        type: 'asset/resource',
+        use: [
+          {
+            loader: '@nuintun/svgo-loader/rspack',
+            options: {
+              configFile: false,
+              multipass: true,
+              plugins: ['preset-default']
+            }
+          }
+        ]
+      }
+    ]
+  }
+};
+```
+
+## Options
+
+All SVGO options are supported (except `path`, which is handled internally by the loader).
+
+### `configFile`
+
+- Type: `string | false`
+- Default: `undefined`
+
+Control how loader reads SVGO config:
+
+- `undefined`: auto load SVGO config from current context
+- `string`: load SVGO config from a specific path
+- `false`: disable external config file
+
+### Common SVGO options
+
+You can pass common SVGO options directly:
+
+- `multipass`
+- `floatPrecision`
+- `plugins`
+- `js2svg`
+- `datauri`
+
+See [SVGO configuration docs](https://github.com/svg/svgo#configuration).
+
+## License
+
+[MIT](./LICENSE)
+
 [npm-image]: https://img.shields.io/npm/v/@nuintun/svgo-loader?style=flat-square
 [npm-url]: https://www.npmjs.org/package/@nuintun/svgo-loader
 [download-image]: https://img.shields.io/npm/dm/@nuintun/svgo-loader?style=flat-square


### PR DESCRIPTION
### Motivation
- Provide clear installation and usage guidance so consumers can quickly integrate the loader with Webpack and Rspack.
- Explain the loader `configFile` behavior and list common SVGO options to reduce configuration confusion.
- Include ready-to-use examples and a license pointer to improve onboarding and documentation completeness.

### Description
- Expanded `README.md` with an `Install` section showing `pnpm add -D @nuintun/svgo-loader svgo`.
- Added `Usage` examples for Webpack and Rspack including a sample rule and `options` (`configFile`, `multipass`, `plugins`).
- Documented `Options` details including `configFile` type/behavior and common SVGO options such as `multipass`, `floatPrecision`, `plugins`, `js2svg`, and `datauri`.
- Added a `License` section linking to the project `LICENSE` file.

### Testing
- Ran `pnpm -s prettier --check README.md` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccc48937ec83338e464ef6462c0173)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added installation instructions for the package
  * Added usage examples for Webpack and Rspack
  * Documented all supported SVGO options and the `configFile` configuration parameter

<!-- end of auto-generated comment: release notes by coderabbit.ai -->